### PR TITLE
DPOS poc initial commit

### DIFF
--- a/jsonstore/jsonstore.go
+++ b/jsonstore/jsonstore.go
@@ -532,7 +532,6 @@ func (app *JSONStoreApplication) CheckTx(tx []byte) types.ResponseCheckTx {
 			codeType = code.CodeTypeBadData
 			break
 		}
-		break
 	}
 
 	// ===== Data Validation =======
@@ -563,7 +562,7 @@ func (app *JSONStoreApplication) EndBlock(req types.RequestEndBlock) types.Respo
 	db.C("validators").Find(nil).Sort("-power").All(&results)
 	var validatorUpdates []types.Validator
 	for i, k := range results {
-		if i < 21 {
+		if i < 3 {
 			validatorUpdates = append(validatorUpdates, types.Validator{Power: k.Power, PubKey: k.PubKey})
 		} else {
 			// All validators beyond first 21 should be removed i.e. power = 0

--- a/jsonstore/jsonstore.go
+++ b/jsonstore/jsonstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"mint/code"
 	"net/url"
@@ -416,7 +417,7 @@ func (app *JSONStoreApplication) DeliverTx(tx []byte) types.ResponseDeliverTx {
 		db.C("validators").Update(bson.M{"_id": validatorID}, bson.M{"$inc": bson.M{"power": 1}})
 		break
 	}
-
+	log.Println(body["type"])
 	return types.ResponseDeliverTx{Code: code.CodeTypeOK, Tags: nil}
 }
 
@@ -535,6 +536,7 @@ func (app *JSONStoreApplication) CheckTx(tx []byte) types.ResponseCheckTx {
 	}
 
 	// ===== Data Validation =======
+	log.Println(codeType, body["type"])
 	return types.ResponseCheckTx{Code: codeType}
 }
 


### PR DESCRIPTION
Initial poc for implementing DPOS. Some notes -

1. A user can upvote validators as many times as they want. We should probably have a limit on the number of upvotes a user can cast in a single day.
2. Currently validator list is updated after all transactions. Although, this wouldn't change the result, this will probably slow down the process. We need the info about last transaction in EndBlock, not sure currently how to get it.
3. We will also need hooks for removal/addition of validators on the fly. Currently validators are only added on genesis. Support for validator addition/removal can be done in future.
4. Data of all validators is stored in db. If a validator dies, the entry currently isn't remove from db(see 3). For updating, we select the first 21 validators with most power and set the other's power to 0(effectively removing from participating in consensus).
5. Although I have written this with multiple validators in mind, but I have only tested it with 1 node.

Note: Tested against tendermint binary 0.19.7-a017f2fd (https://github.com/tendermint/tendermint/releases/tag/v0.19.7)